### PR TITLE
Fix:修复limitVoucher2()方法中的分布式锁key错误

### DIFF
--- a/src/main/java/com/hmdp/service/impl/VoucherOrderServiceImpl.java
+++ b/src/main/java/com/hmdp/service/impl/VoucherOrderServiceImpl.java
@@ -347,7 +347,7 @@ public class VoucherOrderServiceImpl extends ServiceImpl<VoucherOrderMapper, Vou
     public Result limitVoucher2(Long voucherId, int buyNumber) {
         Long userId = UserHolder.getUser().getId();
         // 创建锁对象
-        RLock redisLock = redissonClient.getLock("lock:order:" + userId);
+        RLock redisLock = redissonClient.getLock("lock:order:" + voucherId);
         // 尝试获取锁
         boolean isLock = redisLock.tryLock();
         // 判断
@@ -374,8 +374,6 @@ public class VoucherOrderServiceImpl extends ServiceImpl<VoucherOrderMapper, Vou
                 // 扣减失败
                 return Result.fail("库存不足");
             }
-
-
             // 7.创建订单
             VoucherOrder voucherOrder = new VoucherOrder().setId(redisIdWorker.nextId("order"))
                     .setVoucherId(voucherId)


### PR DESCRIPTION
文档中设计的方法2锁的key为优惠券id；而仓库里代码中的limitVoucher2()锁的key写的是用户id
向作者确认代码是笔误后，修复limitVoucher2()方法中的分布式锁key错误